### PR TITLE
fix texture coordinate order and face vertex indices

### DIFF
--- a/shapes_operator/tera_shape_export.py
+++ b/shapes_operator/tera_shape_export.py
@@ -85,12 +85,13 @@ class TERA_SHAPE_OT_shape_exporter(bpy.types.Operator, bpy_extras.io_utils.Expor
                 NoIndent([-vert.normal.x, vert.normal.z, vert.normal.y]))
 
         uv_active = mesh.uv_layers.active
-        for layer in uv_active.data:
-            result['texcoords'].append(
-                NoIndent([layer.uv[0], 1.0 - layer.uv[1]]))
+        result['texcoords'] = [NoIndent([0,0])for _ in range(0, len(mesh.loops))]
+        for i, layer in enumerate(uv_active.data):
+            result['texcoords'][mesh.loops[i].vertex_index] = NoIndent([layer.uv[0], 1.0 - layer.uv[1]])
+
         mesh.calc_loop_triangles()
         for tri in mesh.loop_triangles:
-            result['faces'].append(NoIndent([i for i in tri.loops]))
+            result['faces'].append(NoIndent([mesh.loops[i].vertex_index for i in tri.loops]))
 
         bpy.data.meshes.remove(mesh)
 

--- a/shapes_operator/tera_shape_export.py
+++ b/shapes_operator/tera_shape_export.py
@@ -85,7 +85,7 @@ class TERA_SHAPE_OT_shape_exporter(bpy.types.Operator, bpy_extras.io_utils.Expor
                 NoIndent([-vert.normal.x, vert.normal.z, vert.normal.y]))
 
         uv_active = mesh.uv_layers.active
-        result['texcoords'] = [NoIndent([0,0])for _ in range(0, len(mesh.loops))]
+        result['texcoords'] = [NoIndent([0,0]) for _ in range(0, len(mesh.loops))]
         for i, layer in enumerate(uv_active.data):
             result['texcoords'][mesh.loops[i].vertex_index] = NoIndent([layer.uv[0], 1.0 - layer.uv[1]])
 


### PR DESCRIPTION
According to https://docs.blender.org/api/current/bpy.types.Mesh.html, Mesh.loops, Mesh.uv_layers Mesh.vertex_colors are all aligned so the same polygon loop indices can be used to find the UV’s and vertex colors as with as the vertices. (Which is a somewhat confusing sentence to be honest.)

I have updated the export script to use the loops[i].vertex_index variable, as well as using this to ensure the list of UV coordinates are aligned with the list of vertices. This corrects an issue I had with exporting a simple mesh to the block shape format, see test module https://github.com/antag99/ShapeTestModule. The blender file under assets/shapes did not export correctly before this fix, but exported correctly afterwards. To test:

- Export assets/shapes/TestBlockShape.blend without the patch
- Create a world with ShapeTestModule enabled
- F1, give ShapeTestModule:TestBlock
- UV coordinates should be all messed up
- Repeat with the patch applied, UV coordinates should be in order

Blender version I use is 2.92.

An alternative option would be to reorder the vertices to match loops instead.